### PR TITLE
Restore connect_timeout error

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -229,6 +229,11 @@ socket_from_pool(Host, Port, Transport, Client0) ->
       Client1 = Client#client{socket_ref=Ref, pool_handler=PoolHandler},
 
       do_connect(Host, Port, Transport, Client1, pool);
+    {error, timeout} ->
+      ?report_trace("connect timeout", []),
+      _ = metrics:increment_counter(Metrics, [hackney, Host, connect_timeout]),
+      hackney_manager:cancel_request(Client),
+      {error, connect_timeout};
     Error ->
       ?report_trace("connect error", []),
       _ = metrics:increment_counter(Metrics, [hackney, Host, connect_error]),

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -9,7 +9,8 @@ dummy_test() ->
 multipart_test_() ->
     {setup, fun start/0, fun stop/1,
       [{timeout, 120, queue_timeout()},
-       {timeout, 120, checkout_timeout()}]}.
+       {timeout, 120, checkout_timeout()},
+       {timeout, 120, connect_timeout()}]}.
 
 start() ->
     error_logger:tty(false),
@@ -55,5 +56,16 @@ checkout_timeout() ->
                 {error, Error} = hackney:request(post, URL, Headers, stream, Opts),
                 hackney:close(Ref),
                 ?assertEqual(Error, checkout_timeout)
+        end
+    end.
+
+connect_timeout() ->
+    fun() ->
+        URL = <<"http://localhost:8123/pool">>,
+        Headers = [],
+        Opts = [{max_body, 2048}, {pool, pool_test}, {connect_timeout, 1}],
+        case hackney:request(post, URL, Headers, stream, Opts) of
+            {error, Error} ->
+                ?assertEqual(Error, connect_timeout)
         end
     end.


### PR DESCRIPTION
This error seems to have disappeared with updates in 1.16.0. This change makes errors related to connection timeouts consistent whether one is using a pool or not.  User reported issue here: https://github.com/benoitc/hackney/issues/698